### PR TITLE
bug: fix issue with loader ordering when using a 3rd party promise library (i.e. bluebird)

### DIFF
--- a/src/Microframework.ts
+++ b/src/Microframework.ts
@@ -108,7 +108,11 @@ export class Microframework {
             }).then(() => {
                 return this.runInSequence(this.loaders, loader => {
                     const loaderResult = loader(settings);
-                    return loaderResult instanceof Promise ? loaderResult : Promise.resolve();
+                    if (loaderResult != null && typeof loaderResult.then !== "function") {
+                        return loaderResult;
+                    } else {
+                        return Promise.resolve();
+                    }
                 });
 
             }).then(() => {


### PR DESCRIPTION
An issue was identified when using Bluebird as a global promise library. When using an `async` function as a loader, loaders are completed out of order (multiple run simultaneously) because `async/await` always return an instance of the _native_ promise rather than the Bluebird promise, so the original check of  `loaderResult instanceof Promise` will never be true.

https://github.com/petkaantonov/bluebird/issues/1595
